### PR TITLE
fixes startup error deploying against Oracle on clean database

### DIFF
--- a/bbb-tool/impl/src/java/org/sakaiproject/bbb/impl/sql/OracleGenerator.java
+++ b/bbb-tool/impl/src/java/org/sakaiproject/bbb/impl/sql/OracleGenerator.java
@@ -38,4 +38,8 @@ public class OracleGenerator extends DefaultSqlGenerator
 		//return "select TNAME from tab where TABTYPE='TABLE' and TNAME='" + table + "'";
 		return "select * from user_objects where OBJECT_TYPE='TABLE' and OBJECT_NAME='" + table + "'";
 	}
+
+    public String getShowColumnStatement(String tableName, String columnName) {
+        return "SELECT column_name FROM user_tab_cols WHERE table_name = '" + tableName + "' and column_name like '"+columnName+"'";
+    }
 }


### PR DESCRIPTION
We were getting this error against an Oracle 10g database. 

This is invalid sql for Oracle

SHOW COLUMNS FROM BBB_MEETING LIKE 'HOST_URL'

This pull request converts it to something like this:

SELECT column_name
FROM user_tab_cols
WHERE table_name = 'BBB_MEETING' and column_name like 'HOST_URL'

2013-04-11 14:00:48,274 ERROR pool-2-thread-1 org.sakaiproject.bbb.impl.BBBStorageManager - Caught exception whilst setting up tables. Rolling back ... 
java.sql.SQLException: ORA-00900: invalid SQL statement 

at oracle.jdbc.driver.DatabaseError.throwSqlException(DatabaseError.java:112) 
at oracle.jdbc.driver.T4CTTIoer.processError(T4CTTIoer.java:331) 
at oracle.jdbc.driver.T4CTTIoer.processError(T4CTTIoer.java:288) 
at oracle.jdbc.driver.T4C8Oall.receive(T4C8Oall.java:745) 
at oracle.jdbc.driver.T4CStatement.doOall8(T4CStatement.java:207) 
at oracle.jdbc.driver.T4CStatement.executeForRows(T4CStatement.java:957) 
at oracle.jdbc.driver.OracleStatement.doExecuteWithTimeout(OracleStatement.java:1170) 
at oracle.jdbc.driver.OracleStatement.executeQuery(OracleStatement.java:1274) 
at org.apache.commons.dbcp.DelegatingStatement.executeQuery(DelegatingStatement.java:208) 
at org.sakaiproject.bbb.impl.BBBStorageManager.setupTables(BBBStorageManager.java:145) 
at org.sakaiproject.bbb.impl.BBBMeetingManagerImpl.init(BBBMeetingManagerImpl.java:130) 
