### PR TITLE
upgrade lombok version

### DIFF
--- a/bbb-tool/api/pom.xml
+++ b/bbb-tool/api/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
         	<groupId>org.projectlombok</groupId>
         	<artifactId>lombok</artifactId>
-        	<version>0.9.3</version>
+        	<version>0.10.6</version>
         </dependency> 
 	</dependencies>
 </project>


### PR DESCRIPTION
we were having issues running the tool against openjdk 1.7 without upgrading this.  Since jdk 1.6 is eol, probably a good idea to fix this, so no one else runs into it.
